### PR TITLE
downgrade react router dom to v5

### DIFF
--- a/micro-frontends-module-federation/catalogue/package.json
+++ b/micro-frontends-module-federation/catalogue/package.json
@@ -17,7 +17,7 @@
         "@material-ui/icons": "^4.11.2",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-router-dom": "^6.2.1"
+        "react-router-dom": "^5.3.0"
     },
     "devDependencies": {
         "@babel/core": "^7.13.15",

--- a/micro-frontends-module-federation/catalogue/src/Details.js
+++ b/micro-frontends-module-federation/catalogue/src/Details.js
@@ -1,7 +1,7 @@
 import React from "react";
 import {Link, useParams} from "react-router-dom";
 
-const Home = () => {
+const Details = () => {
 
     const {productId} = useParams()
 
@@ -14,4 +14,4 @@ const Home = () => {
     )
 }
 
-export default Home;
+export default Details;

--- a/micro-frontends-module-federation/myaccount/package.json
+++ b/micro-frontends-module-federation/myaccount/package.json
@@ -16,7 +16,7 @@
         "nanoevents": "^6.0.2",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-router-dom": "^6.2.1"
+        "react-router-dom": "^5.3.0"
     },
     "devDependencies": {
         "@babel/core": "^7.16.12",

--- a/micro-frontends-module-federation/signin/package.json
+++ b/micro-frontends-module-federation/signin/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "catalogue",
+    "name": "signin",
     "version": "1.0.0",
     "description": "",
     "main": "index.js",
@@ -16,7 +16,7 @@
         "@material-ui/core": "^4.11.3",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
-        "react-router-dom": "^6.2.1"
+        "react-router-dom": "^5.3.0"
     },
     "devDependencies": {
         "@babel/core": "^7.13.15",


### PR DESCRIPTION
Description of changes:
While running the code from Main branch, it was noticed that the app shell does load MFE apps and upon investigating it was due to using react-router-dom v6 however the components used such as useHistory and useRouteMatch are no longer supported in v6 (they are supported in v5).


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.